### PR TITLE
Fix database inconsistencies, allow writing to skeletonrecord

### DIFF
--- a/src/main/java/nl/knaw/dans/catalog/core/UseCases.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/UseCases.java
@@ -78,7 +78,9 @@ public class UseCases {
 
     @UnitOfWork
     public OcflObjectVersion createOcflObjectVersion(OcflObjectVersionId id, OcflObjectVersionParameters parameters) throws OcflObjectVersionAlreadyExistsException {
-        var existingOcflObjectVersion = ocflObjectVersionRepository.findByBagIdAndVersion(id.getBagId(), id.getObjectVersion());
+        // in case of skeletonRecord, allow writing
+        var existingOcflObjectVersion = ocflObjectVersionRepository.findByBagIdAndVersion(id.getBagId(), id.getObjectVersion())
+            .filter(ocflObjectVersion -> !ocflObjectVersion.isSkeletonRecord());
 
         if (existingOcflObjectVersion.isPresent()) {
             throw new OcflObjectVersionAlreadyExistsException(id.getBagId(), id.getObjectVersion());

--- a/src/main/java/nl/knaw/dans/catalog/db/OcflObjectVersion.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/OcflObjectVersion.java
@@ -16,18 +16,33 @@
 
 package nl.knaw.dans.catalog.db;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 import nl.knaw.dans.catalog.core.domain.OcflObjectVersionId;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 
 @Entity
-@Table(name = "ocfl_object_versions", uniqueConstraints = {@UniqueConstraint(columnNames = {"bag_id", "object_version"})})
+@Table(name = "ocfl_object_versions", uniqueConstraints = { @UniqueConstraint(columnNames = { "bag_id", "object_version" }) })
 @Getter
 @Setter
 @ToString
@@ -46,7 +61,7 @@ public class OcflObjectVersion {
     private String bagId;
     @Column(name = "object_version", nullable = false)
     private Integer objectVersion;
-    @ManyToOne
+    @ManyToOne(cascade = { CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH })
     @JoinColumn(name = "tar_uuid")
     private Tar tar;
     @Column(name = "data_supplier")
@@ -84,8 +99,10 @@ public class OcflObjectVersion {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o)) return false;
+        if (this == o)
+            return true;
+        if (o == null || Hibernate.getClass(this) != Hibernate.getClass(o))
+            return false;
         OcflObjectVersion that = (OcflObjectVersion) o;
         return getId() != null && Objects.equals(getId(), that.getId());
     }
@@ -93,5 +110,13 @@ public class OcflObjectVersion {
     @Override
     public int hashCode() {
         return getClass().hashCode();
+    }
+
+    Long getInternalId() {
+        return id;
+    }
+
+    void setInternalId(Long id) {
+        this.id = id;
     }
 }

--- a/src/main/java/nl/knaw/dans/catalog/db/OcflObjectVersionDAO.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/OcflObjectVersionDAO.java
@@ -64,7 +64,13 @@ public class OcflObjectVersionDAO extends AbstractDAO<OcflObjectVersion> impleme
 
     @Override
     public OcflObjectVersion save(OcflObjectVersion ocflObjectVersion) {
-        return persist(ocflObjectVersion);
+        findByBagIdAndVersion(ocflObjectVersion.getBagId(), ocflObjectVersion.getObjectVersion())
+            .ifPresent(item -> {
+                ocflObjectVersion.setInternalId(item.getInternalId());
+            });
+
+        var merged = (OcflObjectVersion) (currentSession().merge(ocflObjectVersion));
+        return persist(merged);
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/catalog/db/Tar.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/Tar.java
@@ -43,7 +43,7 @@ public class Tar {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "tar")
     @ToString.Exclude
     private List<TarPart> tarParts = new ArrayList<>();
-    @OneToMany(cascade = {CascadeType.ALL}, mappedBy = "tar")
+    @OneToMany(cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH}, mappedBy = "tar")
     @ToString.Exclude
     private List<OcflObjectVersion> ocflObjectVersions = new ArrayList<>();
 

--- a/src/main/java/nl/knaw/dans/catalog/db/TarDAO.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/TarDAO.java
@@ -47,7 +47,8 @@ public class TarDAO extends AbstractDAO<Tar> implements TarRepository {
             part.setTar(tar);
         }
 
-        return persist(tar);
+        var merged = (Tar) currentSession().merge(tar);
+        return persist(merged);
     }
 
     @Override
@@ -63,6 +64,10 @@ public class TarDAO extends AbstractDAO<Tar> implements TarRepository {
     }
 
     void delete(Tar tar) {
+        for (var version: tar.getOcflObjectVersions()) {
+            version.setTar(null);
+        }
+
         currentSession().delete(tar);
         currentSession().flush();
     }

--- a/src/main/java/nl/knaw/dans/catalog/db/TarPart.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/TarPart.java
@@ -41,8 +41,8 @@ public class TarPart {
     private String checksumAlgorithm;
     @Column(name = "checksum_value")
     private String checksumValue;
-    @ManyToOne
-    @JoinColumn(name = "tar_uuid")
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "tar_uuid", nullable = false)
     private Tar tar;
 
     @Override

--- a/src/main/java/nl/knaw/dans/catalog/resource/api/OcflObjectApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resource/api/OcflObjectApiResource.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.catalog.resource.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 import nl.knaw.dans.catalog.api.OcflObjectVersionParametersDto;
 import nl.knaw.dans.catalog.core.UseCases;
@@ -24,7 +23,6 @@ import nl.knaw.dans.catalog.core.exception.OcflObjectVersionAlreadyExistsExcepti
 import nl.knaw.dans.catalog.resource.OcflObjectApi;
 import nl.knaw.dans.catalog.resource.mappers.OcflObjectVersionMapper;
 
-import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.util.stream.Collectors;
@@ -54,6 +52,10 @@ public class OcflObjectApiResource implements OcflObjectApi {
         catch (OcflObjectVersionAlreadyExistsException e) {
             log.error(e.getMessage());
             throw new WebApplicationException(e.getMessage(), Response.Status.CONFLICT);
+        }
+        catch (Throwable e) {
+            log.error(e.getMessage(), e);
+            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/nl/knaw/dans/catalog/db/TarRepositoryTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/db/TarRepositoryTest.java
@@ -105,8 +105,6 @@ class TarRepositoryTest {
             tar.setOcflObjectVersions(List.of(version1));
             tar.setTarParts(List.of(part1));
 
-            ocflObjectVersionRepository.save(version1);
-
             tarRepository.save(tar);
             tarRepository.evict(tar);
         });

--- a/src/test/java/nl/knaw/dans/catalog/resource/api/OcflObjectApiResourceTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/resource/api/OcflObjectApiResourceTest.java
@@ -218,6 +218,34 @@ class OcflObjectApiResourceTest {
         }
     }
 
+    @Test
+    public void createOcflVersion_should_allow_writing_to_SkeletonRecord() throws Exception {
+        var client = new JerseyClientBuilder().build();
+        var entity = new OcflObjectVersionParametersDto()
+            .dataSupplier("test")
+            .skeletonRecord(true)
+            .nbn("someNbn");
+
+        var str = SUPPORT.getObjectMapper().writeValueAsString(entity);
+        var bagId = UUID.randomUUID().toString();
+        var version = 1;
+
+        var url = String.format("http://localhost:%d/ocflObject/bagId/%s/version/%s", SUPPORT.getLocalPort(), bagId, version);
+
+        // creating ocfl object
+        try (var response = client.target(url).request().put(Entity.json(str))) {
+            assertEquals(201, response.getStatus());
+        }
+
+        entity.dataSupplier(null);
+        str = SUPPORT.getObjectMapper().writeValueAsString(entity);
+
+        // verify it also returns true on the next request
+        try (var response = client.target(url).request().put(Entity.json(str))) {
+            assertEquals(201, response.getStatus());
+        }
+    }
+
     Map<String, Object> getMetadata() throws JsonProcessingException {
         var str = "{\n" +
             "  \"dcterms:modified\": \"2021-11-17\",\n" +


### PR DESCRIPTION
Fixes DD-1384

# Description of changes

After discussing a possible error that would occur when writing a first version, I found that the inverse is actually true; it will not allow you to write a second time to the same record.

This was fine at first, but with the introduction of skeleton records this is obviously a feature that should be allowed. 

# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/dataversedans
