### PR TITLE
We got a 400 Bad Request when saving a new DVE. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.knaw.dans</groupId>
         <artifactId>dd-parent</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>dd-vault-catalog</artifactId>
@@ -39,7 +39,6 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>0.3.0</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/nl/knaw/dans/catalog/core/Dataset.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/Dataset.java
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.catalog.core;
 
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,7 +31,6 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Entity

--- a/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
@@ -16,15 +16,22 @@
 package nl.knaw.dans.catalog.core;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 import javax.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -72,9 +79,9 @@ public class DatasetVersionExport {
     @Column(name = "other_id_version")
     private String otherIdVersion;
 
-//    @Lob
-//    @Column(name = "metadata", columnDefinition = "TEXT")
-//    private String metadata;
+    @Lob
+    @Column(name = "metadata", columnDefinition = "TEXT")
+    private String metadata;
 
     @Column(name = "file_to_local_path")
     private String fileToLocalPath;

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -79,7 +79,9 @@ public class DatasetApiResource implements DatasetApi {
             return Response.ok().build();
         }
         else if (ocflObjectVersion.equals(latestDveInCatalog.getOcflObjectVersionNumber() + 1)) {
-            dataset.getDatasetVersionExports().add(conversions.convert(versionExportDto));
+            var datasetVersionExport = conversions.convert(versionExportDto);
+            datasetVersionExport.setDataset(dataset); // No way to have this done automatically in an after-mapping method it seems.
+            dataset.getDatasetVersionExports().add(datasetVersionExport);
             datasetDao.save(dataset);
             log.debug("Saved dataset; returning 200 OK");
             return Response.ok().build();

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetView.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetView.java
@@ -18,14 +18,51 @@ package nl.knaw.dans.catalog.resources;
 import io.dropwizard.views.common.View;
 import lombok.Getter;
 import nl.knaw.dans.catalog.core.Dataset;
+import nl.knaw.dans.catalog.core.DatasetVersionExport;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 public class DatasetView extends View {
 
     private final Dataset dataset;
+    private final List<DatasetVersionExport> datasetVersionExports;
 
     protected DatasetView(Dataset dataset) {
         super("dataset.ftl");
+        /*
+         * N.B. Everything to be displayed must be fetched from the database before the View object leaves the @UnitOfWork
+         * scope. Otherwise, the database may be accessed outside a transaction (especially for LOB fields), which is not
+         * allowed. This is even true for fields that are not explicitly references from the template, such as 'metadata'.
+         * As an alternative, the complete Dataset, DVE and all its fields could be fetched eagerly, but that could be
+         * inefficient.
+         */
         this.dataset = dataset;
+        this.datasetVersionExports = copyWithoutMetadataField(dataset.getDatasetVersionExports());
+    }
+
+    private List<DatasetVersionExport> copyWithoutMetadataField(List<DatasetVersionExport> original) {
+        List<DatasetVersionExport> copy = new ArrayList<>();
+        for (DatasetVersionExport dve : original) {
+            DatasetVersionExport dveCopy = new DatasetVersionExport();
+            dveCopy.setId(dve.getId());
+            dveCopy.setDataset(dve.getDataset());
+            dveCopy.setBagId(dve.getBagId());
+            dveCopy.setOcflObjectVersionNumber(dve.getOcflObjectVersionNumber());
+            dveCopy.setCreatedTimestamp(dve.getCreatedTimestamp());
+            dveCopy.setArchiveTimestamp(dve.getArchiveTimestamp());
+            dveCopy.setDataversePidVersion(dve.getDataversePidVersion());
+            dveCopy.setOtherId(dve.getOtherId());
+            dveCopy.setOtherIdVersion(dve.getOtherIdVersion());
+            dveCopy.setMetadata(null); // Not displayed, so avoid retrieving it from the database
+            dveCopy.setFileToLocalPath(dve.getFileToLocalPath());
+            dveCopy.setDeaccessioned(dve.getDeaccessioned());
+            dveCopy.setExporter(dve.getExporter());
+            dveCopy.setExporterVersion(dve.getExporterVersion());
+            dveCopy.setSkeletonRecord(dve.getSkeletonRecord());
+            copy.add(dveCopy);
+        }
+        return copy;
     }
 }

--- a/src/main/resources/nl/knaw/dans/catalog/resources/dataset.ftl
+++ b/src/main/resources/nl/knaw/dans/catalog/resources/dataset.ftl
@@ -37,7 +37,9 @@
     </#if>
 </table>
 
-<#list dataset.datasetVersionExports as dve>
+<#-- Do not use dataset.datasetVersionExports, as it trigger a fetch of the 'metadata' field from outside the
+     @UnitOfWork scope, causing a Hibernate exception -->
+<#list datasetVersionExports as dve>
     <h3>v${dve.ocflObjectVersionNumber!"n/a"}</h3>
     <#if dve.deaccessioned??>
         <p class="deaccessioned">This version has been deaccessioned</p>


### PR DESCRIPTION
Fixes DD-1492

# Description of changes
This was caused by the dataset field not being set to the parent Dataset. This probably caused an exception after the web resource method nl.knaw.dans.catalog.resources.DatasetApiResource#setVersionExport had returned, somewhere in the Jersey framework when the save action through the JPA was being flushed. No details where logged or returned to the client, so it was hard to analyze. Setting the dataset field solves the problem.


# How to test

# Related PRs

(Add links)

*

# Notify

@DANS-KNAW/core-systems
