### PR TITLE
DD-2094 Updated column length of title and filepath

### DIFF
--- a/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
@@ -81,7 +81,7 @@ public class DatasetVersionExport {
 
     @Column(name = "title", length = 300)
     private String title;
-    
+
     @Column(name = "dataverse_pid_version")
     private String dataversePidVersion;
 
@@ -110,17 +110,18 @@ public class DatasetVersionExport {
     @OneToMany(mappedBy = "versionExport", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude
     private List<FileMeta> fileMetas = new ArrayList<>();
-    
+
     public void addFileMeta(FileMeta fileMeta) {
         fileMetas.add(fileMeta);
         fileMeta.setVersionExport(this);
     }
 
-    // Ensure title does not exceed 300 characters when stored
     public void setTitle(String title) {
-        if (title != null && title.length() > 300) {
-            this.title = title.substring(0, 300);
-        } else {
+        final String ellipsis = "...";
+        if (title != null && title.length() > 300 - ellipsis.length()) {
+            this.title = title.substring(0, 300 - ellipsis.length()) + ellipsis;
+        }
+        else {
             this.title = title;
         }
     }

--- a/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
@@ -118,7 +118,7 @@ public class DatasetVersionExport {
 
     public void setTitle(String title) {
         final String ellipsis = "...";
-        if (title != null && title.length() > 300 - ellipsis.length()) {
+        if (title != null && title.length() > 300) {
             this.title = title.substring(0, 300 - ellipsis.length()) + ellipsis;
         }
         else {

--- a/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java
@@ -79,7 +79,7 @@ public class DatasetVersionExport {
     @Column(name = "archived_timestamp")
     private OffsetDateTime archivedTimestamp;
 
-    @Column(name = "title")
+    @Column(name = "title", length = 300)
     private String title;
     
     @Column(name = "dataverse_pid_version")
@@ -114,5 +114,14 @@ public class DatasetVersionExport {
     public void addFileMeta(FileMeta fileMeta) {
         fileMetas.add(fileMeta);
         fileMeta.setVersionExport(this);
+    }
+
+    // Ensure title does not exceed 300 characters when stored
+    public void setTitle(String title) {
+        if (title != null && title.length() > 300) {
+            this.title = title.substring(0, 300);
+        } else {
+            this.title = title;
+        }
     }
 }

--- a/src/main/java/nl/knaw/dans/catalog/core/FileMeta.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/FileMeta.java
@@ -57,7 +57,8 @@ public class FileMeta {
     @JsonIgnore
     private DatasetVersionExport versionExport;
 
-    @Column(name = "filepath", nullable = false)
+    // length = 2 * 255 + some margin
+    @Column(name = "filepath", nullable = false, length = 520)
     private String filepath;
 
     @Column(name = "file_uri", nullable = false)

--- a/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
@@ -29,17 +29,17 @@ public class DatasetVersionExportTest {
     }
 
     @Test
-    public void setTitle_should_keep_title_when_length_is_at_most_297() {
-        var title = "a".repeat(297);
+    public void setTitle_should_keep_title_when_length_is_at_most_300() {
+        var title = "a".repeat(300);
         var dve = new DatasetVersionExport();
         dve.setTitle(title);
         assertThat(dve.getTitle()).isEqualTo(title);
-        assertThat(dve.getTitle()).hasSize(297);
+        assertThat(dve.getTitle()).hasSize(300);
     }
 
     @Test
-    public void setTitle_should_ellipsize_when_length_exceeds_297() {
-        var original = "x".repeat(350);
+    public void setTitle_should_ellipsize_when_length_exceeds_300() {
+        var original = "x".repeat(301);
         var dve = new DatasetVersionExport();
         dve.setTitle(original);
         assertThat(dve.getTitle()).isNotNull();

--- a/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.catalog.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DatasetVersionExportTest {
+
+    @Test
+    public void setTitle_should_allow_null() {
+        var dve = new DatasetVersionExport();
+        dve.setTitle(null);
+        assertThat(dve.getTitle()).isNull();
+    }
+
+    @Test
+    public void setTitle_should_keep_title_when_length_is_at_most_300() {
+        var title = "a".repeat(300);
+        var dve = new DatasetVersionExport();
+        dve.setTitle(title);
+        assertThat(dve.getTitle()).isEqualTo(title);
+        assertThat(dve.getTitle()).hasSize(300);
+    }
+
+    @Test
+    public void setTitle_should_truncate_when_length_exceeds_300() {
+        var original = "x".repeat(350);
+        var dve = new DatasetVersionExport();
+        dve.setTitle(original);
+        assertThat(dve.getTitle()).isNotNull();
+        assertThat(dve.getTitle()).hasSize(300);
+        assertThat(dve.getTitle()).isEqualTo(original.substring(0, 300));
+    }
+}

--- a/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java
@@ -29,21 +29,21 @@ public class DatasetVersionExportTest {
     }
 
     @Test
-    public void setTitle_should_keep_title_when_length_is_at_most_300() {
-        var title = "a".repeat(300);
+    public void setTitle_should_keep_title_when_length_is_at_most_297() {
+        var title = "a".repeat(297);
         var dve = new DatasetVersionExport();
         dve.setTitle(title);
         assertThat(dve.getTitle()).isEqualTo(title);
-        assertThat(dve.getTitle()).hasSize(300);
+        assertThat(dve.getTitle()).hasSize(297);
     }
 
     @Test
-    public void setTitle_should_truncate_when_length_exceeds_300() {
+    public void setTitle_should_ellipsize_when_length_exceeds_297() {
         var original = "x".repeat(350);
         var dve = new DatasetVersionExport();
         dve.setTitle(original);
         assertThat(dve.getTitle()).isNotNull();
         assertThat(dve.getTitle()).hasSize(300);
-        assertThat(dve.getTitle()).isEqualTo(original.substring(0, 300));
+        assertThat(dve.getTitle()).isEqualTo(original.substring(0, 297) + "...");
     }
 }


### PR DESCRIPTION
Fixes DD-2094

### Summary
Enforce a maximum length of 297 characters for dataset titles in `dd-vault-catalog`, appending an ellipsis when truncation is needed. Update the database column definition accordingly and add/adjust unit tests.

### What’s changed
- Application logic: Titles longer than 300 characters are truncated to 297 characters plus `...` (total 300).
  - File: `modules/dd-vault-catalog/src/main/java/nl/knaw/dans/catalog/core/DatasetVersionExport.java`
  - Method: `setTitle(String title)` enforces `297 + "..."` when length exceeds 300.
- Database schema mapping: JPA column length explicitly set to 300.
  - `@Column(name = "title", length = 300)` on `title` field.
- Tests: Added and updated unit tests to reflect the ellipsis behavior.
  - File: `modules/dd-vault-catalog/src/test/java/nl/knaw/dans/catalog/core/DatasetVersionExportTest.java`
  - Tests:
    - `setTitle_should_allow_null`
    - `setTitle_should_keep_title_when_length_is_at_most_297`
    - `setTitle_should_ellipsize_when_length_exceeds_297`

### Motivation
- Prevent database errors and ensure consistent display by capping stored title length.
- Provide user-friendly truncation with an ellipsis rather than hard cutting at 300.
- Align application behavior with schema constraints for predictability.


### Checklist
- [x] Application-level enforcement of title length with ellipsis
- [x] JPA mapping updated to `length = 300`
- [x] Unit tests added/updated and passing
- [ ] Database migration (if needed) prepared and executed in deployment pipeline

---
Date: 2025-12-09 16:36
# Notify

@DANS-KNAW/core-systems
