### PR TITLE
Separate add and update dve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-vault-catalog</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>DD Vault Catalog</name>
     <url>https://github.com/DANS-KNAW/dd-vault-catalog</url>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>dd-vault-catalog</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>DD Vault Catalog</name>
     <url>https://github.com/DANS-KNAW/dd-vault-catalog</url>
@@ -39,6 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
+        <dd-vault-catalog-api.version>1.0.0-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.0.0-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -89,6 +89,7 @@ public class DatasetApiResource implements DatasetApi {
     }
 
     @Override
+    @UnitOfWork
     public Response addVersionExport(String nbn, VersionExportDto versionExportDto) {
         var datasetOptional = datasetDao.findByNbn(nbn);
         if (datasetOptional.isEmpty()) {
@@ -101,7 +102,9 @@ public class DatasetApiResource implements DatasetApi {
         if (latestDatasetVersionExportOptional.isPresent() && latestDatasetVersionExportOptional.get().getOcflObjectVersionNumber() + 1 != versionExportDto.getOcflObjectVersionNumber()) {
             return Response.status(Status.CONFLICT).entity("ocflVersionNumber must be one higher than latest existing version's").build();
         }
-        dataset.getDatasetVersionExports().add(conversions.convert(versionExportDto));
+        var versionExport = conversions.convert(versionExportDto);
+        versionExport.setDataset(dataset);
+        dataset.getDatasetVersionExports().add(versionExport);
         datasetDao.save(dataset);
         return Response.ok().build();
     }

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -31,9 +31,13 @@ import org.apache.hc.core5.http.message.BasicHeaderValueParser;
 import org.apache.hc.core5.http.message.ParserCursor;
 import org.mapstruct.factory.Mappers;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -63,30 +67,43 @@ public class DatasetApiResource implements DatasetApi {
 
     @Override
     @UnitOfWork
-    public Response setVersionExport(String nbn, Integer ocflObjectVersion, VersionExportDto versionExportDto) {
+    public Response updateVersionExport(String nbn, Integer ocflObjectVersion, VersionExportDto versionExportDto) {
         var datasetOptional = datasetDao.findByNbn(nbn);
         if (datasetOptional.isEmpty()) {
             return Response.status(Response.Status.NOT_FOUND).entity("Dataset not found").build();
         }
         var dataset = datasetOptional.get();
-        var latestDveInCatalog = dataset.getDatasetVersionExports().stream()
-            .max(Comparator.comparing(DatasetVersionExport::getOcflObjectVersionNumber)).orElseThrow(() -> new IllegalStateException("No DatasetVersionExports found for dataset with NBN " + nbn));
-        if (ocflObjectVersion.equals(latestDveInCatalog.getOcflObjectVersionNumber())) {
-            conversions.updateVersionExportFromDto(versionExportDto, latestDveInCatalog);
-            datasetDao.save(dataset);
-            return Response.ok().build();
+        var datasetVersionExportOptional = dataset.getDatasetVersionExports().stream()
+            .filter(dve -> dve.getOcflObjectVersionNumber().equals(versionExportDto.getOcflObjectVersionNumber()))
+            .findFirst();
+        if (datasetVersionExportOptional.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).entity("DatasetVersionExport not found").build();
         }
-        else if (ocflObjectVersion.equals(latestDveInCatalog.getOcflObjectVersionNumber() + 1)) {
-            var datasetVersionExport = conversions.convert(versionExportDto);
-            datasetVersionExport.setDataset(dataset); // No way to have this done automatically in an after-mapping method it seems.
-            dataset.getDatasetVersionExports().add(datasetVersionExport);
-            datasetDao.save(dataset);
-            log.debug("Saved dataset; returning 200 OK");
-            return Response.ok().build();
+        var datasetVersionExport = datasetVersionExportOptional.get();
+        if (!datasetVersionExport.getSkeletonRecord()) {
+            return Response.status(Response.Status.CONFLICT).entity("Not a skeleton record. Cannot update").build();
         }
-        else {
-            return Response.status(Response.Status.BAD_REQUEST).entity("Invalid ocflObjectVersion; it must be equal or one greater than the latest DVE stored").build();
+        conversions.updateVersionExportFromDto(versionExportDto, datasetVersionExport);
+        datasetDao.save(dataset);
+        return Response.ok().build();
+    }
+
+    @Override
+    public Response addVersionExport(String nbn, VersionExportDto versionExportDto) {
+        var datasetOptional = datasetDao.findByNbn(nbn);
+        if (datasetOptional.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Dataset not found").build();
         }
+        var dataset = datasetOptional.get();
+        var latestDatasetVersionExportOptional = dataset.getDatasetVersionExports().stream()
+            .max(Comparator.comparing(DatasetVersionExport::getOcflObjectVersionNumber));
+
+        if (latestDatasetVersionExportOptional.isPresent() && latestDatasetVersionExportOptional.get().getOcflObjectVersionNumber() + 1 != versionExportDto.getOcflObjectVersionNumber()) {
+            return Response.status(Status.CONFLICT).entity("ocflVersionNumber must be one higher than latest existing version's").build();
+        }
+        dataset.getDatasetVersionExports().add(conversions.convert(versionExportDto));
+        datasetDao.save(dataset);
+        return Response.ok().build();
     }
 
     @Override


### PR DESCRIPTION
NO JIRA

# Description of changes
This PR implements a new version of the API which changes the version export handling by splitting a single `setVersionExport` method into two separate operations: `updateVersionExport` for modifying existing skeleton records and `addVersionExport` for creating new version exports. The version number is bumped to 2.0.1-SNAPSHOT to reflect this breaking API change.

**Changes:**
- Split `setVersionExport` into dedicated `updateVersionExport` and `addVersionExport` methods
- Added validation to ensure only skeleton records can be updated
- Introduced API version property in pom.xml


# Notify

@DANS-KNAW/core-systems
