### PR TITLE
DD-2416 Handle large JSON-LD

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.0.0</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.0.1-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.0.1-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.1.0</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/nl/knaw/dans/catalog/Conversions.java
+++ b/src/main/java/nl/knaw/dans/catalog/Conversions.java
@@ -15,9 +15,6 @@
  */
 package nl.knaw.dans.catalog;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.knaw.dans.catalog.api.DatasetDto;
 import nl.knaw.dans.catalog.api.FileMetaDto;
 import nl.knaw.dans.catalog.api.VersionExportDto;
@@ -30,10 +27,14 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
-import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Conversion between DTOs and domain objects.
@@ -69,11 +70,13 @@ public interface Conversions {
     @Mapping(target = "datasetNbn", source = "dataset.nbn")
     @Mapping(target = "removeFileMetasItem", ignore = true) // Not sure why mapstruct thinks the removeFileMetasItem method is a property
     @Mapping(target = "fileMetas", source = "datasetVersionExport.fileMetas", qualifiedByName = "mapFileMetaListToFileMetaDtoList")
+    @Mapping(target = "metadataEncoding", constant = "PLAIN")
     VersionExportDto convert(DatasetVersionExport datasetVersionExport);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "dataset", ignore = true)
     @Mapping(target = "fileMetas", source = "versionExportDto.fileMetas", qualifiedByName = "mapFileMetaDtoListToFileMetaList")
+    @Mapping(target = "metadata", source = "versionExportDto", qualifiedByName = "decompressMetadata")
     DatasetVersionExport convert(VersionExportDto versionExportDto);
 
     @AfterMapping
@@ -85,7 +88,26 @@ public interface Conversions {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "dataset", ignore = true)
+    @Mapping(target = "metadata", source = "versionExportDto", qualifiedByName = "decompressMetadata")
     void updateVersionExportFromDto(VersionExportDto versionExportDto, @MappingTarget DatasetVersionExport datasetVersionExport);
+
+    @Named("decompressMetadata")
+    default String decompressMetadata(VersionExportDto versionExportDto) {
+        if (versionExportDto.getMetadata() == null) {
+            return null;
+        }
+        if (VersionExportDto.MetadataEncodingEnum.GZIP_BASE64.equals(versionExportDto.getMetadataEncoding())) {
+            try {
+                byte[] decoded = Base64.getDecoder().decode(versionExportDto.getMetadata());
+                try (var gzipIn = new GZIPInputStream(new ByteArrayInputStream(decoded))) {
+                    return new String(gzipIn.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Failed to decode gzip-base64 metadata", e);
+            }
+        }
+        return versionExportDto.getMetadata();
+    }
 
     @Named("mapVersionExportDtoListToDatasetVersionExportList")
     default List<DatasetVersionExport> mapVersionExportDtoListToDatasetVersionExportList(List<VersionExportDto> versionExportDtoList) {

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -31,10 +31,7 @@ import org.apache.hc.core5.http.message.BasicHeaderValueParser;
 import org.apache.hc.core5.http.message.ParserCursor;
 import org.mapstruct.factory.Mappers;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;

--- a/src/test/java/nl/knaw/dans/catalog/ConversionsTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/ConversionsTest.java
@@ -24,8 +24,12 @@ import nl.knaw.dans.catalog.core.FileMeta;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
+import java.io.ByteArrayOutputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -618,6 +622,25 @@ public class ConversionsTest {
         assertThat(datasetDto.getVersionExports().get(1).getFileMetas().get(1).getByteSize()).isEqualTo(400L);
     }
     
+    @Test
+    public void convert_VersionExportDto_with_GzipBase64_metadata() throws Exception {
+        var originalMetadata = "this is some metadata that should be compressed";
+        var out = new ByteArrayOutputStream();
+        try (var gzip = new GZIPOutputStream(out)) {
+            gzip.write(originalMetadata.getBytes(StandardCharsets.UTF_8));
+        }
+        var encodedMetadata = Base64.getEncoder().encodeToString(out.toByteArray());
+        
+        var dveDto = new VersionExportDto()
+            .bagId("urn:uuid:1234")
+            .metadataEncoding(VersionExportDto.MetadataEncodingEnum.GZIP_BASE64)
+            .metadata(encodedMetadata);
+
+        var dve = conversions.convert(dveDto);
+
+        assertThat(dve.getMetadata()).isEqualTo(originalMetadata);
+    }
+
     @Test
     public void convert_DatasetDto_to_Dataset() {
         var fileMetaDto1 = new FileMetaDto()


### PR DESCRIPTION
Fixes DD-2416

# Description of changes
This pull request introduces support for handling GZIP-compressed and Base64-encoded metadata in `VersionExportDto` objects. The main changes include updating the conversion logic to automatically decompress such metadata during mapping, updating dependencies, and adding a dedicated test to verify this functionality.

**Enhancements to metadata handling:**

* Added a `decompressMetadata` method in `Conversions.java` that detects if the `metadataEncoding` is `GZIP_BASE64` and, if so, decodes and decompresses the `metadata` field when converting from `VersionExportDto` to `DatasetVersionExport`. This ensures that compressed metadata is transparently handled.
* Updated the `@Mapping` annotations in `Conversions.java` to use the new `decompressMetadata` method when mapping metadata fields. [[1]](diffhunk://#diff-ab1548d7a9e64e4cc33d29c459328ac4b1f1dcdb9d785c86fbebf3b2cc0fc442R73-R79) [[2]](diffhunk://#diff-ab1548d7a9e64e4cc33d29c459328ac4b1f1dcdb9d785c86fbebf3b2cc0fc442R91-R111)

**Dependency and version updates:**

* Bumped the `dd-vault-catalog-api.version` property in `pom.xml` from `1.0.0` to `1.1.0` to reflect the new API capabilities.
* Cleaned up unused imports in `Conversions.java` and `DatasetApiResource.java`. [[1]](diffhunk://#diff-ab1548d7a9e64e4cc33d29c459328ac4b1f1dcdb9d785c86fbebf3b2cc0fc442L18-L20) [[2]](diffhunk://#diff-ab1548d7a9e64e4cc33d29c459328ac4b1f1dcdb9d785c86fbebf3b2cc0fc442R30-R37) [[3]](diffhunk://#diff-b5429a2d338ac382beb542ecb959791ad00cd1b1581ac5fe132f1775974011feL34-L37)

**Testing improvements:**

* Added a test in `ConversionsTest.java` to verify that GZIP-compressed and Base64-encoded metadata is correctly decompressed and mapped. [[1]](diffhunk://#diff-460628763349e6d199463bf6b040250244aade4c105d6a48f9ec88a7e9b9d1a7R27-R32) [[2]](diffhunk://#diff-460628763349e6d199463bf6b040250244aade4c105d6a48f9ec88a7e9b9d1a7R625-R643)


# Notify

@DANS-KNAW/core-systems
