### PR TITLE
DD-2384 Implement delete-dataset-version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.1.0-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.2.0-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.1.0</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.1.0-SNAPSHOT</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
     <properties>
         <main-class>nl.knaw.dans.catalog.DdVaultCatalogApplication</main-class>
-        <dd-vault-catalog-api.version>1.2.0-SNAPSHOT</dd-vault-catalog-api.version>
+        <dd-vault-catalog-api.version>1.2.0</dd-vault-catalog-api.version>
     </properties>
 
     <dependencies>

--- a/src/main/assembly/dist/cfg/config.yml
+++ b/src/main/assembly/dist/cfg/config.yml
@@ -34,6 +34,9 @@ database:
     hibernate.dialect: 'org.hibernate.dialect.PostgreSQL95Dialect'
     hibernate.hbm2ddl.auto: update
 
+# Directory where to store the restore SQL scripts for deleted version exports
+restoreScriptsDirectory: /var/opt/dans.knaw.nl/tmp/dd-vault-catalog/restore-scripts
+
 logging:
   level: INFO
   appenders:

--- a/src/main/java/nl/knaw/dans/catalog/DdVaultCatalogApplication.java
+++ b/src/main/java/nl/knaw/dans/catalog/DdVaultCatalogApplication.java
@@ -66,7 +66,7 @@ public class DdVaultCatalogApplication extends Application<DdVaultCatalogConfig>
         var datasetDao = new DatasetDao(hibernateBundle.getSessionFactory());
         var datasetVersionExportDao = new DatasetVersionExportDao(hibernateBundle.getSessionFactory());
         environment.jersey().register(new DefaultApiResource());
-        environment.jersey().register(new DatasetApiResource(datasetDao));
+        environment.jersey().register(new DatasetApiResource(datasetDao, configuration.getRestoreScriptsDirectory()));
         environment.jersey().register(new DatasetVersionExportApiResource(datasetVersionExportDao));
         environment.jersey().register(new UnconfirmedDatasetVersionExportsApiResource(datasetVersionExportDao));
         environment.jersey().register(new DefaultMediaTypeFilter());

--- a/src/main/java/nl/knaw/dans/catalog/config/DdVaultCatalogConfig.java
+++ b/src/main/java/nl/knaw/dans/catalog/config/DdVaultCatalogConfig.java
@@ -24,10 +24,15 @@ import lombok.EqualsAndHashCode;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import java.nio.file.Path;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class DdVaultCatalogConfig extends Configuration {
     @Valid
     @NotNull
     private DataSourceFactory database = new DataSourceFactory();
+
+    @NotNull
+    private Path restoreScriptsDirectory;
 }

--- a/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
@@ -66,7 +66,11 @@ public class SqlRestoreGenerator {
         sql.append("  ").append(escape(export.getDataversePidVersion())).append(",\n");
         sql.append("  ").append(escape(export.getOtherId())).append(",\n");
         sql.append("  ").append(escape(export.getOtherIdVersion())).append(",\n");
-        sql.append("  ").append(escape(export.getMetadata())).append(",\n");
+        if (export.getMetadata() == null) {
+            sql.append("  NULL,\n");
+        } else {
+            sql.append("  lo_from_bytea(0, convert_to(").append(escape(export.getMetadata())).append(", 'UTF8')),\n");
+        }
         sql.append("  ").append(format(export.getDeaccessioned())).append(",\n");
         sql.append("  ").append(escape(export.getExporter())).append(",\n");
         sql.append("  ").append(escape(export.getExporterVersion())).append(",\n");

--- a/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
@@ -44,50 +44,86 @@ public class SqlRestoreGenerator {
         StringBuilder sql = new StringBuilder();
         sql.append("BEGIN;\n\n");
 
+        boolean hasFileMetas = export.getFileMetas() != null && !export.getFileMetas().isEmpty();
+
+        if (includeDataset || hasFileMetas) {
+            sql.append("WITH ");
+        }
+
         if (includeDataset) {
-            sql.append("INSERT INTO dataset (id, nbn, dataverse_pid, sword_token, data_supplier, ocfl_storage_root) VALUES (\n");
-            sql.append("  ").append(dataset.getId()).append(",\n");
-            sql.append("  ").append(escape(dataset.getNbn())).append(",\n");
-            sql.append("  ").append(escape(dataset.getDataversePid())).append(",\n");
-            sql.append("  ").append(escape(dataset.getSwordToken())).append(",\n");
-            sql.append("  ").append(escape(dataset.getDataSupplier())).append(",\n");
-            sql.append("  ").append(escape(dataset.getOcflStorageRoot())).append("\n");
-            sql.append(");\n\n");
-        }
-
-        sql.append("INSERT INTO dataset_version_export (id, dataset_id, bag_id, ocfl_object_version_number, created_timestamp, archived_timestamp, title, dataverse_pid_version, other_id, other_id_version, metadata, deaccessioned, exporter, exporter_version, skeleton_record) VALUES (\n");
-        sql.append("  ").append(export.getId()).append(",\n");
-        sql.append("  ").append(dataset.getId()).append(",\n");
-        sql.append("  ").append(export.getBagId() != null ? escape(export.getBagId().toString()) : "NULL").append(",\n");
-        sql.append("  ").append(format(export.getOcflObjectVersionNumber())).append(",\n");
-        sql.append("  ").append(export.getCreatedTimestamp() != null ? escape(export.getCreatedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
-        sql.append("  ").append(export.getArchivedTimestamp() != null ? escape(export.getArchivedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
-        sql.append("  ").append(escape(export.getTitle())).append(",\n");
-        sql.append("  ").append(escape(export.getDataversePidVersion())).append(",\n");
-        sql.append("  ").append(escape(export.getOtherId())).append(",\n");
-        sql.append("  ").append(escape(export.getOtherIdVersion())).append(",\n");
-        if (export.getMetadata() == null) {
-            sql.append("  NULL,\n");
-        } else {
-            sql.append("  lo_from_bytea(0, convert_to(").append(escape(export.getMetadata())).append(", 'UTF8')),\n");
-        }
-        sql.append("  ").append(format(export.getDeaccessioned())).append(",\n");
-        sql.append("  ").append(escape(export.getExporter())).append(",\n");
-        sql.append("  ").append(escape(export.getExporterVersion())).append(",\n");
-        sql.append("  ").append(format(export.getSkeletonRecord())).append("\n");
-        sql.append(");\n\n");
-
-        if (export.getFileMetas() != null) {
-            for (FileMeta fm : export.getFileMetas()) {
-                sql.append("INSERT INTO file_meta (id, version_export_id, filepath, file_uri, byte_size, sha1sum) VALUES (\n");
-                sql.append("  ").append(fm.getId()).append(",\n");
-                sql.append("  ").append(export.getId()).append(",\n");
-                sql.append("  ").append(escape(fm.getFilepath())).append(",\n");
-                sql.append("  ").append(fm.getFileUri() != null ? escape(fm.getFileUri().toString()) : "NULL").append(",\n");
-                sql.append("  ").append(format(fm.getByteSize())).append(",\n");
-                sql.append("  ").append(escape(fm.getSha1sum())).append("\n");
-                sql.append(");\n\n");
+            sql.append("new_dataset AS (\n");
+            sql.append("  INSERT INTO dataset (nbn, dataverse_pid, sword_token, data_supplier, ocfl_storage_root) VALUES (\n");
+            sql.append("    ").append(escape(dataset.getNbn())).append(",\n");
+            sql.append("    ").append(escape(dataset.getDataversePid())).append(",\n");
+            sql.append("    ").append(escape(dataset.getSwordToken())).append(",\n");
+            sql.append("    ").append(escape(dataset.getDataSupplier())).append(",\n");
+            sql.append("    ").append(escape(dataset.getOcflStorageRoot())).append("\n");
+            sql.append("  ) RETURNING id\n");
+            sql.append(")");
+            
+            if (hasFileMetas) {
+                sql.append(",\n");
+            } else {
+                sql.append("\n");
             }
+        }
+
+        if (hasFileMetas) {
+            sql.append("new_export AS (\n");
+        }
+
+        String indent = hasFileMetas ? "  " : "";
+
+        sql.append(indent).append("INSERT INTO dataset_version_export (dataset_id, bag_id, ocfl_object_version_number, created_timestamp, archived_timestamp, title, dataverse_pid_version, other_id, other_id_version, metadata, deaccessioned, exporter, exporter_version, skeleton_record) VALUES (\n");
+        
+        if (includeDataset) {
+            sql.append(indent).append("  (SELECT id FROM new_dataset),\n");
+        } else {
+            sql.append(indent).append("  ").append(dataset.getId()).append(",\n");
+        }
+
+        sql.append(indent).append("  ").append(export.getBagId() != null ? escape(export.getBagId().toString()) : "NULL").append(",\n");
+        sql.append(indent).append("  ").append(format(export.getOcflObjectVersionNumber())).append(",\n");
+        sql.append(indent).append("  ").append(export.getCreatedTimestamp() != null ? escape(export.getCreatedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
+        sql.append(indent).append("  ").append(export.getArchivedTimestamp() != null ? escape(export.getArchivedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getTitle())).append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getDataversePidVersion())).append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getOtherId())).append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getOtherIdVersion())).append(",\n");
+        
+        if (export.getMetadata() == null) {
+            sql.append(indent).append("  NULL,\n");
+        } else {
+            sql.append(indent).append("  lo_from_bytea(0, convert_to(").append(escape(export.getMetadata())).append(", 'UTF8')),\n");
+        }
+        
+        sql.append(indent).append("  ").append(format(export.getDeaccessioned())).append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getExporter())).append(",\n");
+        sql.append(indent).append("  ").append(escape(export.getExporterVersion())).append(",\n");
+        sql.append(indent).append("  ").append(format(export.getSkeletonRecord())).append("\n");
+
+        if (hasFileMetas) {
+            sql.append(indent).append(") RETURNING id\n");
+            sql.append(")\n");
+            
+            sql.append("INSERT INTO file_meta (version_export_id, filepath, file_uri, byte_size, sha1sum) VALUES \n");
+            
+            java.util.List<FileMeta> metas = new java.util.ArrayList<>(export.getFileMetas());
+            for (int i = 0; i < metas.size(); i++) {
+                FileMeta fm = metas.get(i);
+                sql.append("  ((SELECT id FROM new_export), ");
+                sql.append(escape(fm.getFilepath())).append(", ");
+                sql.append(fm.getFileUri() != null ? escape(fm.getFileUri().toString()) : "NULL").append(", ");
+                sql.append(format(fm.getByteSize())).append(", ");
+                sql.append(escape(fm.getSha1sum())).append(")");
+                if (i < metas.size() - 1) {
+                    sql.append(",\n");
+                } else {
+                    sql.append(";\n\n");
+                }
+            }
+        } else {
+            sql.append(indent).append(");\n\n");
         }
 
         sql.append("COMMIT;\n");

--- a/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
+++ b/src/main/java/nl/knaw/dans/catalog/core/SqlRestoreGenerator.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.catalog.core;
+
+import java.time.format.DateTimeFormatter;
+
+public class SqlRestoreGenerator {
+
+    private static String escape(String value) {
+        if (value == null) {
+            return "NULL";
+        }
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    private static String format(Boolean value) {
+        if (value == null) {
+            return "NULL";
+        }
+        return value ? "TRUE" : "FALSE";
+    }
+
+    private static String format(Number value) {
+        if (value == null) {
+            return "NULL";
+        }
+        return value.toString();
+    }
+
+    public static String generateRestoreSql(Dataset dataset, DatasetVersionExport export, boolean includeDataset) {
+        StringBuilder sql = new StringBuilder();
+        sql.append("BEGIN;\n\n");
+
+        if (includeDataset) {
+            sql.append("INSERT INTO dataset (id, nbn, dataverse_pid, sword_token, data_supplier, ocfl_storage_root) VALUES (\n");
+            sql.append("  ").append(dataset.getId()).append(",\n");
+            sql.append("  ").append(escape(dataset.getNbn())).append(",\n");
+            sql.append("  ").append(escape(dataset.getDataversePid())).append(",\n");
+            sql.append("  ").append(escape(dataset.getSwordToken())).append(",\n");
+            sql.append("  ").append(escape(dataset.getDataSupplier())).append(",\n");
+            sql.append("  ").append(escape(dataset.getOcflStorageRoot())).append("\n");
+            sql.append(");\n\n");
+        }
+
+        sql.append("INSERT INTO dataset_version_export (id, dataset_id, bag_id, ocfl_object_version_number, created_timestamp, archived_timestamp, title, dataverse_pid_version, other_id, other_id_version, metadata, deaccessioned, exporter, exporter_version, skeleton_record) VALUES (\n");
+        sql.append("  ").append(export.getId()).append(",\n");
+        sql.append("  ").append(dataset.getId()).append(",\n");
+        sql.append("  ").append(export.getBagId() != null ? escape(export.getBagId().toString()) : "NULL").append(",\n");
+        sql.append("  ").append(format(export.getOcflObjectVersionNumber())).append(",\n");
+        sql.append("  ").append(export.getCreatedTimestamp() != null ? escape(export.getCreatedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
+        sql.append("  ").append(export.getArchivedTimestamp() != null ? escape(export.getArchivedTimestamp().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)) : "NULL").append(",\n");
+        sql.append("  ").append(escape(export.getTitle())).append(",\n");
+        sql.append("  ").append(escape(export.getDataversePidVersion())).append(",\n");
+        sql.append("  ").append(escape(export.getOtherId())).append(",\n");
+        sql.append("  ").append(escape(export.getOtherIdVersion())).append(",\n");
+        sql.append("  ").append(escape(export.getMetadata())).append(",\n");
+        sql.append("  ").append(format(export.getDeaccessioned())).append(",\n");
+        sql.append("  ").append(escape(export.getExporter())).append(",\n");
+        sql.append("  ").append(escape(export.getExporterVersion())).append(",\n");
+        sql.append("  ").append(format(export.getSkeletonRecord())).append("\n");
+        sql.append(");\n\n");
+
+        if (export.getFileMetas() != null) {
+            for (FileMeta fm : export.getFileMetas()) {
+                sql.append("INSERT INTO file_meta (id, version_export_id, filepath, file_uri, byte_size, sha1sum) VALUES (\n");
+                sql.append("  ").append(fm.getId()).append(",\n");
+                sql.append("  ").append(export.getId()).append(",\n");
+                sql.append("  ").append(escape(fm.getFilepath())).append(",\n");
+                sql.append("  ").append(fm.getFileUri() != null ? escape(fm.getFileUri().toString()) : "NULL").append(",\n");
+                sql.append("  ").append(format(fm.getByteSize())).append(",\n");
+                sql.append("  ").append(escape(fm.getSha1sum())).append("\n");
+                sql.append(");\n\n");
+            }
+        }
+
+        sql.append("COMMIT;\n");
+
+        return sql.toString();
+    }
+}

--- a/src/main/java/nl/knaw/dans/catalog/db/DatasetDao.java
+++ b/src/main/java/nl/knaw/dans/catalog/db/DatasetDao.java
@@ -63,4 +63,8 @@ public class DatasetDao extends AbstractDAO<Dataset> {
             throw new IllegalArgumentException(e.getSQLException().getMessage());
         }
     }
+
+    public void delete(Dataset dataset) {
+        currentSession().delete(dataset);
+    }
 }

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -185,7 +185,7 @@ public class DatasetApiResource implements DatasetApi {
 
     @Override
     @UnitOfWork
-    public Response deleteVersionExport(String nbn, Integer ocflObjectVersion) {
+    public Response deleteVersionExport(String nbn, Integer ocflObjectVersion, Boolean force) {
         var datasetOptional = datasetDao.findByNbn(nbn);
         if (datasetOptional.isEmpty()) {
             return Response.status(Response.Status.NOT_FOUND).entity("Dataset not found").build();
@@ -197,6 +197,16 @@ public class DatasetApiResource implements DatasetApi {
         if (datasetVersionExportOptional.isEmpty()) {
             return Response.status(Response.Status.NOT_FOUND).entity("DatasetVersionExport not found").build();
         }
+        
+        var latestVersion = dataset.getDatasetVersionExports().stream()
+            .map(DatasetVersionExport::getOcflObjectVersionNumber)
+            .max(Integer::compareTo)
+            .orElse(0);
+            
+        if (!ocflObjectVersion.equals(latestVersion) && !Boolean.TRUE.equals(force)) {
+            return Response.status(Response.Status.BAD_REQUEST).entity("Cannot delete non-latest version export without force").build();
+        }
+
         var datasetVersionExport = datasetVersionExportOptional.get();
 
         boolean deleteDataset = dataset.getDatasetVersionExports().size() == 1;

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -205,11 +205,11 @@ public class DatasetApiResource implements DatasetApi {
         
         try {
             Files.createDirectories(restoreScriptsDirectory);
-            String filename = String.format("restore_%s_%d_%s.sql", 
-                nbn.replace(":", "_"), 
-                ocflObjectVersion, 
-                DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss").format(LocalDateTime.now()));
-            Files.writeString(restoreScriptsDirectory.resolve(filename), sql);
+            String safeNbn = nbn.replaceAll("[^A-Za-z0-9._-]", "_");
+            String timestamp = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss_SSS").format(LocalDateTime.now());
+            String filename = String.format("restore_%s_%d_%s.sql", safeNbn, ocflObjectVersion, timestamp);
+            var target = restoreScriptsDirectory.resolve(filename);
+            Files.writeString(target, sql, java.nio.file.StandardOpenOption.CREATE_NEW);
         } catch (IOException e) {
             log.error("Failed to write restore script", e);
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Failed to write restore script").build();

--- a/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
+++ b/src/main/java/nl/knaw/dans/catalog/resources/DatasetApiResource.java
@@ -25,6 +25,7 @@ import nl.knaw.dans.catalog.api.DatasetDto;
 import nl.knaw.dans.catalog.api.VersionExportDto;
 import nl.knaw.dans.catalog.core.Dataset;
 import nl.knaw.dans.catalog.core.DatasetVersionExport;
+import nl.knaw.dans.catalog.core.SqlRestoreGenerator;
 import nl.knaw.dans.catalog.db.DatasetDao;
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.message.BasicHeaderValueParser;
@@ -35,7 +36,12 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
@@ -47,6 +53,9 @@ public class DatasetApiResource implements DatasetApi {
 
     @NonNull
     private final DatasetDao datasetDao;
+    
+    @NonNull
+    private final Path restoreScriptsDirectory;
 
     @Override
     @UnitOfWork
@@ -172,5 +181,47 @@ public class DatasetApiResource implements DatasetApi {
             .findFirst()
             .orElseThrow(() -> new NotFoundException("DatasetVersionExport not found"));
         return Response.ok(conversions.convert(datasetVersionExport)).build();
+    }
+
+    @Override
+    @UnitOfWork
+    public Response deleteVersionExport(String nbn, Integer ocflObjectVersion) {
+        var datasetOptional = datasetDao.findByNbn(nbn);
+        if (datasetOptional.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).entity("Dataset not found").build();
+        }
+        var dataset = datasetOptional.get();
+        var datasetVersionExportOptional = dataset.getDatasetVersionExports().stream()
+            .filter(dve -> dve.getOcflObjectVersionNumber().equals(ocflObjectVersion))
+            .findFirst();
+        if (datasetVersionExportOptional.isEmpty()) {
+            return Response.status(Response.Status.NOT_FOUND).entity("DatasetVersionExport not found").build();
+        }
+        var datasetVersionExport = datasetVersionExportOptional.get();
+
+        boolean deleteDataset = dataset.getDatasetVersionExports().size() == 1;
+
+        String sql = SqlRestoreGenerator.generateRestoreSql(dataset, datasetVersionExport, deleteDataset);
+        
+        try {
+            Files.createDirectories(restoreScriptsDirectory);
+            String filename = String.format("restore_%s_%d_%s.sql", 
+                nbn.replace(":", "_"), 
+                ocflObjectVersion, 
+                DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss").format(LocalDateTime.now()));
+            Files.writeString(restoreScriptsDirectory.resolve(filename), sql);
+        } catch (IOException e) {
+            log.error("Failed to write restore script", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("Failed to write restore script").build();
+        }
+
+        if (deleteDataset) {
+            datasetDao.delete(dataset);
+        } else {
+            dataset.getDatasetVersionExports().remove(datasetVersionExport);
+            datasetDao.save(dataset);
+        }
+
+        return Response.noContent().build();
     }
 }

--- a/src/test/java/nl/knaw/dans/catalog/core/SqlRestoreGeneratorTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/core/SqlRestoreGeneratorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.catalog.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SqlRestoreGeneratorTest {
+
+    @Test
+    void generateRestoreSql_should_include_dataset_insert_if_requested() throws Exception {
+        var dataset = new Dataset();
+        dataset.setId(1L);
+        dataset.setNbn("urn:nbn:nl:ui:13-1234");
+        dataset.setDataversePid("doi:10.1234/5678");
+        dataset.setSwordToken("sword:123");
+        dataset.setDataSupplier("DataSupplier");
+        dataset.setOcflStorageRoot("/path/to/root");
+
+        var export = new DatasetVersionExport();
+        export.setId(10L);
+        export.setDataset(dataset);
+        export.setBagId(new URI("urn:uuid:12345678-1234-1234-1234-123456789012"));
+        export.setOcflObjectVersionNumber(1);
+        export.setCreatedTimestamp(OffsetDateTime.of(2023, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC));
+        export.setArchivedTimestamp(OffsetDateTime.of(2023, 1, 2, 12, 0, 0, 0, ZoneOffset.UTC));
+        export.setTitle("My Title");
+        export.setDataversePidVersion("1.0");
+        export.setOtherId("other-1");
+        export.setOtherIdVersion("1.1");
+        export.setMetadata("some metadata");
+        export.setDeaccessioned(false);
+        export.setExporter("Exporter");
+        export.setExporterVersion("1.0");
+        export.setSkeletonRecord(false);
+
+        var fileMeta = new FileMeta();
+        fileMeta.setId(100L);
+        fileMeta.setVersionExport(export);
+        fileMeta.setFilepath("data/file.txt");
+        fileMeta.setFileUri(new URI("http://example.com/file.txt"));
+        fileMeta.setByteSize(1024L);
+        fileMeta.setSha1sum("abcdef123456");
+
+        export.addFileMeta(fileMeta);
+
+        String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, true);
+
+        assertThat(sql).contains("BEGIN;");
+        assertThat(sql).contains("INSERT INTO dataset");
+        assertThat(sql).contains("VALUES (");
+        assertThat(sql).contains("1,");
+        assertThat(sql).contains("'urn:nbn:nl:ui:13-1234',");
+        assertThat(sql).contains("'doi:10.1234/5678',");
+        assertThat(sql).contains("'sword:123',");
+        assertThat(sql).contains("'DataSupplier',");
+        assertThat(sql).contains("'/path/to/root'");
+
+        assertThat(sql).contains("INSERT INTO dataset_version_export");
+        assertThat(sql).contains("10,");
+        assertThat(sql).contains("'urn:uuid:12345678-1234-1234-1234-123456789012',");
+        assertThat(sql).contains("1,");
+        assertThat(sql).contains("'2023-01-01T12:00:00Z',");
+        assertThat(sql).contains("'2023-01-02T12:00:00Z',");
+        assertThat(sql).contains("'My Title',");
+        assertThat(sql).contains("FALSE,");
+        assertThat(sql).contains("'Exporter',");
+
+        assertThat(sql).contains("INSERT INTO file_meta");
+        assertThat(sql).contains("100,");
+        assertThat(sql).contains("'data/file.txt',");
+        assertThat(sql).contains("'http://example.com/file.txt',");
+        assertThat(sql).contains("1024,");
+        assertThat(sql).contains("'abcdef123456'");
+        
+        assertThat(sql).contains("COMMIT;");
+    }
+
+    @Test
+    void generateRestoreSql_should_not_include_dataset_insert_if_not_requested() {
+        var dataset = new Dataset();
+        dataset.setId(1L);
+        
+        var export = new DatasetVersionExport();
+        export.setId(10L);
+        export.setDataset(dataset);
+        export.setOcflObjectVersionNumber(1);
+
+        String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, false);
+
+        assertThat(sql).doesNotContain("INSERT INTO dataset (");
+        assertThat(sql).contains("INSERT INTO dataset_version_export");
+    }
+
+    @Test
+    void generateRestoreSql_should_escape_single_quotes() {
+        var dataset = new Dataset();
+        dataset.setId(1L);
+        dataset.setNbn("urn:nbn:nl:ui:13-1234");
+        dataset.setDataversePid("doi:10.1234/5678");
+        dataset.setOcflStorageRoot("/path/to/root");
+        
+        var export = new DatasetVersionExport();
+        export.setId(10L);
+        export.setDataset(dataset);
+        export.setOcflObjectVersionNumber(1);
+        export.setTitle("Title with 'single quotes'");
+
+        String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, false);
+
+        assertThat(sql).contains("'Title with ''single quotes'''");
+    }
+
+    @Test
+    void generateRestoreSql_should_handle_null_values() {
+        var dataset = new Dataset();
+        dataset.setId(1L);
+        
+        var export = new DatasetVersionExport();
+        export.setId(10L);
+        export.setDataset(dataset);
+        export.setOcflObjectVersionNumber(1);
+        // leaving many fields null, including boolean, string, numbers, dates
+
+        String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, true);
+
+        // check that "NULL" without quotes is printed for null values instead of "null" string
+        assertThat(sql).contains("  1,\n  NULL,\n  NULL,\n  NULL,\n  NULL,\n  NULL\n);"); // for dataset (id 1, rest nulls)
+    }
+}

--- a/src/test/java/nl/knaw/dans/catalog/core/SqlRestoreGeneratorTest.java
+++ b/src/test/java/nl/knaw/dans/catalog/core/SqlRestoreGeneratorTest.java
@@ -65,17 +65,18 @@ class SqlRestoreGeneratorTest {
         String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, true);
 
         assertThat(sql).contains("BEGIN;");
-        assertThat(sql).contains("INSERT INTO dataset");
-        assertThat(sql).contains("VALUES (");
-        assertThat(sql).contains("1,");
+        assertThat(sql).contains("WITH new_dataset AS (");
+        assertThat(sql).contains("INSERT INTO dataset (nbn, dataverse_pid, sword_token, data_supplier, ocfl_storage_root) VALUES (");
         assertThat(sql).contains("'urn:nbn:nl:ui:13-1234',");
         assertThat(sql).contains("'doi:10.1234/5678',");
         assertThat(sql).contains("'sword:123',");
         assertThat(sql).contains("'DataSupplier',");
         assertThat(sql).contains("'/path/to/root'");
+        assertThat(sql).contains(") RETURNING id");
 
+        assertThat(sql).contains("new_export AS (");
         assertThat(sql).contains("INSERT INTO dataset_version_export");
-        assertThat(sql).contains("10,");
+        assertThat(sql).contains("(SELECT id FROM new_dataset),");
         assertThat(sql).contains("'urn:uuid:12345678-1234-1234-1234-123456789012',");
         assertThat(sql).contains("1,");
         assertThat(sql).contains("'2023-01-01T12:00:00Z',");
@@ -85,7 +86,7 @@ class SqlRestoreGeneratorTest {
         assertThat(sql).contains("'Exporter',");
 
         assertThat(sql).contains("INSERT INTO file_meta");
-        assertThat(sql).contains("100,");
+        assertThat(sql).contains("((SELECT id FROM new_export),");
         assertThat(sql).contains("'data/file.txt',");
         assertThat(sql).contains("'http://example.com/file.txt',");
         assertThat(sql).contains("1024,");
@@ -143,6 +144,29 @@ class SqlRestoreGeneratorTest {
         String sql = SqlRestoreGenerator.generateRestoreSql(dataset, export, true);
 
         // check that "NULL" without quotes is printed for null values instead of "null" string
-        assertThat(sql).contains("  1,\n  NULL,\n  NULL,\n  NULL,\n  NULL,\n  NULL\n);"); // for dataset (id 1, rest nulls)
+        assertThat(sql).contains("WITH new_dataset AS (\n" +
+                                 "  INSERT INTO dataset (nbn, dataverse_pid, sword_token, data_supplier, ocfl_storage_root) VALUES (\n" +
+                                 "    NULL,\n" +
+                                 "    NULL,\n" +
+                                 "    NULL,\n" +
+                                 "    NULL,\n" +
+                                 "    NULL\n" +
+                                 "  ) RETURNING id\n" +
+                                 ")");
+        assertThat(sql).contains("  (SELECT id FROM new_dataset),\n" +
+                                 "  NULL,\n" +
+                                 "  1,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL,\n" +
+                                 "  NULL\n" +
+                                 ");\n");
     }
 }

--- a/src/test/resources/debug-etc/config.yml
+++ b/src/test/resources/debug-etc/config.yml
@@ -18,6 +18,8 @@ database:
   user: dd_vault_catalog_local_test
   password: dd_vault_catalog_local_test
 
+restoreScriptsDirectory: data/restore-scripts
+
 #database:
 #  driverClass: org.hsqldb.jdbcDriver
 #  url: jdbc:hsqldb:hsql://localhost:9001/dd-vault-catalog


### PR DESCRIPTION
Fixes DD-2384

# Description of changes
This pull request introduces a new feature for deleting a dataset version export. This is intended to support recovery of DVEs that failed during transfer to Vault. The new function creates an SQL script to reverse the deletion, so that accidental use can be repaired.


# Notify

@DANS-KNAW/core-systems
